### PR TITLE
Add default render modes in `ToGymEnv.metadata`

### DIFF
--- a/gym3/interop.py
+++ b/gym3/interop.py
@@ -260,7 +260,7 @@ class ToGymEnv:
         assert env.num == 1
         self.observation_space = _vt2space(env.ob_space)
         self.action_space = _vt2space(env.ac_space)
-        self.metadata = {"render.modes": []}
+        self.metadata = {"render.modes": ["human", "rgb_array"]}
         self.reward_range = (-float("inf"), float("inf"))
         self.spec = None
 


### PR DESCRIPTION
`rgb_array` in `env.metadata["render.modes"]` is needed by `gym.wrappers.Monitor` to record the videos.