### PR TITLE
fix not displaying end of episode info when first is true

### DIFF
--- a/gym3/interactive.py
+++ b/gym3/interactive.py
@@ -254,6 +254,8 @@ class Interactive:
                             self._episode_return,
                         )
                     )
+                if first:
+                    break
 
         if first:
             print(f"final info={self._last_info}")


### PR DESCRIPTION
Looks like if multiple simulation steps are done, only the final first value will be used for determining when to display the end of episode info.  The simplest fix looks to be to break out of the multiple step loop.