### PR TITLE
Update seed() of ToGymEnv to improve compatibility

### DIFF
--- a/gym3/interop.py
+++ b/gym3/interop.py
@@ -287,7 +287,7 @@ class ToGymEnv:
         if mode == "rgb_array" and "rgb" in info:
             return info["rgb"]
 
-    def seed(self):
+    def seed(self, *args):
         print("Warning: seed ignored")
 
     def close(self):


### PR DESCRIPTION
A lot of gym workflows tend to create sets of environments and seed them before use, and since most gym seed methods take an argument, most frameworks attempt to provide one, resulting in an error. Adding *args makes the ToGymEnv compatible without changing behavior.