### PR TITLE
[codex] Pin GitHub Actions workflow references

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ jobs:
         os: ["ubuntu-18.04", "macos-10.15", "windows-2019"]
         python-version: ["3.6"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1.5.0
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: goanpeca/setup-miniconda@40011eeb7744a1040f7d1f14c03664ae79f67737 # v1.5.0
         with:
           auto-update-conda: true
           environment-file: environment.yml


### PR DESCRIPTION
Pin floating external GitHub Actions workflow refs to immutable SHAs.

Why are we doing this? Please see the rationale doc: https://docs.google.com/document/d/1qOURCNx2zszQ0uWx7Fj5ERu4jpiYjxLVWBWgKa2wTsA/edit?tab=t.0

Did this break you? Please roll back and let hintz@ know
